### PR TITLE
Bugfix: image turns greyscale

### DIFF
--- a/lock
+++ b/lock
@@ -77,7 +77,7 @@ do
     if (( $OUTPUT_IMG_WIDTH < $SCREEN_WIDTH+$SCREEN_X )); then OUTPUT_IMG_WIDTH=$(($SCREEN_WIDTH+$SCREEN_X)); fi;
     if (( $OUTPUT_IMG_HEIGHT < $SCREEN_HEIGHT+$SCREEN_Y )); then OUTPUT_IMG_HEIGHT=$(( $SCREEN_HEIGHT+$SCREEN_Y )); fi;
 
-    PARAMS="$PARAMS $CACHE_IMG -geometry +$SCREEN_X+$SCREEN_Y -composite "
+    PARAMS="$PARAMS -type TrueColor $CACHE_IMG -geometry +$SCREEN_X+$SCREEN_Y -composite "
   fi
 done <<<"`xrandr`"
 


### PR DESCRIPTION
On some devices `convert` generates greyscale lock screen image for me. Shouldn't hurt to force input as a color image.

System info:
```
$ uname -r && convert --version && xrandr
5.3.5-arch1-1-ARCH
Version: ImageMagick 7.0.8-68 Q16 x86_64 2019-10-06 https://imagemagick.org
Copyright: © 1999-2019 ImageMagick Studio LLC
License: https://imagemagick.org/script/license.php
Features: Cipher DPC HDRI Modules OpenCL OpenMP(4.5) 
Delegates (built-in): bzlib cairo fontconfig freetype heic jbig jng jp2 jpeg lcms lqr ltdl lzma openexr pangocairo png raqm raw rsvg tiff webp wmf x xml zlib
Screen 0: minimum 8 x 8, current 5760 x 2160, maximum 32767 x 32767
eDP1 connected primary 1920x1080+0+0 (normal left inverted right x axis y axis) 280mm x 160mm
   1920x1080     60.02*+  59.93    48.03  
   1680x1050     59.88  
   1400x1050     59.98  
   1600x900      60.00    59.95    59.82  
   1280x1024     60.02  
   1400x900      59.96    59.88  
   1280x960      60.00  
   1368x768      60.00    59.88    59.85  
   1280x800      59.81    59.91  
   1280x720      59.86    60.00    59.74  
   1024x768      60.00  
   1024x576      60.00    59.90    59.82  
   960x540       60.00    59.63    59.82  
   800x600       60.32    56.25  
   864x486       60.00    59.92    59.57  
   640x480       59.94  
   720x405       59.51    60.00    58.99  
   640x360       59.84    59.32    60.00  
DP1 disconnected (normal left inverted right x axis y axis)
DP2 disconnected (normal left inverted right x axis y axis)
HDMI1 connected 3840x2160+1920+0 (normal left inverted right x axis y axis) 940mm x 530mm
   3840x2160     29.98*+  30.00    25.00    24.00    29.97    23.98    24.00  
   2048x1080     59.99  
   1920x1080     60.00    60.00    50.00    50.00    59.94  
   1920x1080i    60.00    50.00    59.94  
   1680x1050     59.88  
   1280x1024     75.02    60.02  
   1440x900      74.98    59.90  
   1280x960      60.00  
   1280x720      60.00    59.94  
   1024x768      75.03    60.00  
   800x600       75.00    60.32  
   720x576       50.00  
   720x576i      50.00  
   720x480       60.00    59.94  
   720x480i      60.00    59.94  
   640x480       75.00    72.81    66.67    60.00    59.94  
   720x400       70.08  
HDMI2 disconnected (normal left inverted right x axis y axis)
VIRTUAL1 disconnected (normal left inverted right x axis y axis)
```

Before:
```
$ identify img/cache/*
img/cache/1920x1080.dc5dd63a1f.png PNG 1920x1080 1920x1080+0+0 8-bit sRGB 4831750B 0.000u 0:00.000
img/cache/3840x2160.dc5dd63a1f.png PNG 3840x2160 3840x2160+0+0 8-bit sRGB 13.2375MiB 0.000u 0:00.000
img/cache/de74f3f2a5699a20139d63898966bfee.dc5dd63a1f.png PNG 5760x2160 5760x2160+0+0 8-bit Gray 256c 6.3051MiB 0.000u 0:00.000
```

After:
```
$ identify img/cache/*
img/cache/1920x1080.dc5dd63a1f.png PNG 1920x1080 1920x1080+0+0 8-bit sRGB 4831750B 0.000u 0:00.000
img/cache/3840x2160.dc5dd63a1f.png PNG 3840x2160 3840x2160+0+0 8-bit sRGB 13.2375MiB 0.000u 0:00.000
img/cache/de74f3f2a5699a20139d63898966bfee.dc5dd63a1f.png PNG 5760x2160 5760x2160+0+0 8-bit sRGB 18.3684MiB 0.000u 0:00.000
```