### PR TITLE
Use default system dirs

### DIFF
--- a/lock
+++ b/lock
@@ -2,8 +2,7 @@
 
 #Constants
 DISPLAY_RE="([0-9]+)x([0-9]+)\\+([0-9]+)\\+([0-9]+)" # Regex to find display dimensions
-FOLDER=`dirname "$BASH_SOURCE"` # Current folder
-CACHE_FOLDER="$FOLDER"/img/cache/ # Cache folder
+CACHE_FOLDER="$HOME"/.cache/i3lock-multimonitor/img/ # Cache folder
 if ! [ -e $CACHE_FOLDER ]; then
     mkdir -p $CACHE_FOLDER
 fi
@@ -23,8 +22,10 @@ done
 #Image paths
 if [ "$arg_image" ]; then
     BKG_IMG="$arg_image"  # Passed image
+elif [ -f "/usr/share/i3lock-multimonitor/img/background.png" ]; then
+    BKG_IMG="/usr/share/i3lock-multimonitor/img/background.png"  # Default image
 else
-    BKG_IMG="$FOLDER/img/background.png"  # Default
+    BKG_IMG="$(dirname "$BASH_SOURCE")/img/background.png"  # Fallback to current folder
 fi
 
 if ! [ -e "$BKG_IMG" ]; then


### PR DESCRIPTION
This PR sets default system directories:

- `~/.cache/i3lock-multimonitor` - for caching
- `/usr/share/i3lock-multimonitor` - for the default resources

It will allow to prepare aur package with i3lock-multimonitor, and place it to
- `/usr/bin/i3lock-multimonitor` 