### PR TITLE
Add sRGB colorspace parameter

### DIFF
--- a/lock
+++ b/lock
@@ -2,7 +2,7 @@
 
 #Constants
 DISPLAY_RE="([0-9]+)x([0-9]+)\\+([0-9]+)\\+([0-9]+)" # Regex to find display dimensions
-PARAMS="-colorspace sRGB" # ensure that images are created in the correct colorspace
+PARAMS="-colorspace sRGB" # ensure that images are created in sRGB colorspace, to avoid greyscale output
 CACHE_FOLDER="$HOME"/.cache/i3lock-multimonitor/img/ # Cache folder
 if ! [ -e $CACHE_FOLDER ]; then
     mkdir -p $CACHE_FOLDER

--- a/lock
+++ b/lock
@@ -2,6 +2,7 @@
 
 #Constants
 DISPLAY_RE="([0-9]+)x([0-9]+)\\+([0-9]+)\\+([0-9]+)" # Regex to find display dimensions
+PARAMS="-colorspace sRGB" # ensure that images are created in the correct colorspace
 CACHE_FOLDER="$HOME"/.cache/i3lock-multimonitor/img/ # Cache folder
 if ! [ -e $CACHE_FOLDER ]; then
     mkdir -p $CACHE_FOLDER


### PR DESCRIPTION
When I updated to ImageMagick v7, my lockscreen images would start to show up in greyscale only. Adding the colorspace parameter ensures that the image is created with the correct color channels. (ref: ImageMagick/ImageMagick#4271)