### PR TITLE
Added trailing slash check for cache folder

### DIFF
--- a/lock
+++ b/lock
@@ -13,6 +13,10 @@ else
     CACHE_FOLDER=$XDG_CACHE_HOME
 fi
 
+if ! [[ "$CACHE_FOLDER" == "*/" ]]; then
+    CACHE_FOLDER="$CACHE_FOLDER/"
+fi
+
 # Create the cache folder if it does not exist
 if ! [ -e $CACHE_FOLDER ]; then
     mkdir -p $CACHE_FOLDER
@@ -84,7 +88,7 @@ do
     SCREEN_HEIGHT=${BASH_REMATCH[2]}
     SCREEN_X=${BASH_REMATCH[3]}
     SCREEN_Y=${BASH_REMATCH[4]}
-    
+
     CACHE_IMG="$CACHE_FOLDER""$SCREEN_WIDTH"x"$SCREEN_HEIGHT"."$MD5_BKG_IMG".png
     ## if cache for that screensize doesnt exist
     if ! [ -e $CACHE_IMG ]


### PR DESCRIPTION
If cache folder dose not include trailing slash then path to the bg image (calculated at lines 56 and 92) will look something like `~/.cahce1920x1080.asasasdvsav.sadfasfdwrgg.png` and they will pollute home folder